### PR TITLE
Updating the Conversation doc link and removing the Dialog tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ To begin working with the  services, see their tutorial pages:
 
 - [AlchemyLanguage](https://www.ibm.com/watson/developercloud/doc/alchemylanguage/tutorials.html)
 - [Conversation](https://console.bluemix.net/docs/services/conversation/tutorial.html#tutorial)
-- [Dialog](https://console.bluemix.net/docs/services/conversation/tutorial.html#tutorial)
 - [Document Conversion](https://www.ibm.com/watson/developercloud/doc/document-conversion/tutorial.html)
 - [Knowledge Studio](http://www.ibm.com/watson/developercloud/doc/wks/wks_tutorials.shtml)
 - [Language Translator](https://www.ibm.com/watson/developercloud/doc/language-translator/customizing.html)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ These are the example files for the IBM Watson&trade; service tutorials:
 To begin working with the  services, see their tutorial pages:
 
 - [AlchemyLanguage](https://www.ibm.com/watson/developercloud/doc/alchemylanguage/tutorials.html)
-- [Conversation](http://www.ibm.com/watson/developercloud/doc/conversation/tutorial.html)
-- [Dialog](https://www.ibm.com/watson/developercloud/doc/dialog/tutorial_tutorials.html)
+- [Conversation](https://console.bluemix.net/docs/services/conversation/tutorial.html#tutorial)
+- [Dialog](https://console.bluemix.net/docs/services/conversation/tutorial.html#tutorial)
 - [Document Conversion](https://www.ibm.com/watson/developercloud/doc/document-conversion/tutorial.html)
 - [Knowledge Studio](http://www.ibm.com/watson/developercloud/doc/wks/wks_tutorials.shtml)
 - [Language Translator](https://www.ibm.com/watson/developercloud/doc/language-translator/customizing.html)


### PR DESCRIPTION
The Conversation service doc moved from WDC to Bluemix Docs. And the Dialog service will no longer be supported as of August 9, so removing mention of it from the readme.