### PR TITLE
update example workspace to say Assistant

### DIFF
--- a/conversation/conversation-simple-example.json
+++ b/conversation/conversation-simple-example.json
@@ -1,223 +1,177 @@
 {
-   "name":"conversation-simple-example",
-   "created":"2017-01-06T16:15:57.864Z",
-   "intents":[
-      {
-         "intent":"goodbye",
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "examples":[
-            {
-               "text":"Bye",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"Farewell",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"Goodbye",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"I am leaving.",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"I'm leaving",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"Sayonara",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"See you later",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            }
-         ],
-         "description":null
+  "name": "assistant-simple-example",
+  "intents": [
+    {
+      "intent": "time",
+      "examples": [
+        {
+          "text": "Give me the time."
+        },
+        {
+          "text": "Is it late?"
+        },
+        {
+          "text": "Tell me the hour of the day."
+        },
+        {
+          "text": "What is the current time?"
+        },
+        {
+          "text": "What time is it?"
+        },
+        {
+          "text": "What time of day is it"
+        }
+      ],
+      "description": null
+    },
+    {
+      "intent": "goodbye",
+      "examples": [
+        {
+          "text": "Bye"
+        },
+        {
+          "text": "See you later"
+        },
+        {
+          "text": "Sayonara"
+        },
+        {
+          "text": "I'm leaving"
+        },
+        {
+          "text": "I am leaving."
+        },
+        {
+          "text": "Goodbye"
+        },
+        {
+          "text": "Farewell"
+        }
+      ],
+      "description": null
+    },
+    {
+      "intent": "hello",
+      "examples": [
+        {
+          "text": "good morning"
+        },
+        {
+          "text": "greetings"
+        },
+        {
+          "text": "hello"
+        },
+        {
+          "text": "hi"
+        },
+        {
+          "text": "howdy"
+        },
+        {
+          "text": "I am here"
+        },
+        {
+          "text": "I have arrived"
+        }
+      ],
+      "description": null
+    }
+  ],
+  "entities": [],
+  "language": "en",
+  "metadata": {
+    "api_version": {
+      "major_version": "v1",
+      "minor_version": "2017-05-26"
+    }
+  },
+  "description": "A simple Assistant workspace that can detect three intents: #hello, #time, and #goodbye.",
+  "dialog_nodes": [
+    {
+      "type": "standard",
+      "title": null,
+      "output": {
+        "text": {
+          "values": [
+            "Sorry, I have no idea what you're talking about."
+          ]
+        }
       },
-      {
-         "intent":"hello",
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "examples":[
-            {
-               "text":"good morning",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"greetings",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"hello",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"hi",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"howdy",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"I am here",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"I have arrived",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            }
-         ],
-         "description":null
+      "parent": null,
+      "context": null,
+      "metadata": null,
+      "next_step": null,
+      "conditions": "anything_else",
+      "description": null,
+      "dialog_node": "node_2_1479323591143",
+      "previous_sibling": "node_1_1479840416664"
+    },
+    {
+      "type": "standard",
+      "title": null,
+      "output": {
+        "text": "OK! See you later.",
+        "action": "end_conversation"
       },
-      {
-         "intent":"time",
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "examples":[
-            {
-               "text":"Give me the time.",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"Is it late?",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"Tell me the hour of the day.",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"What is the current time?",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"What time is it?",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            },
-            {
-               "text":"What time of day is it",
-               "created":"2017-01-06T16:15:57.864Z",
-               "updated":"2017-01-06T16:15:57.864Z"
-            }
-         ],
-         "description":null
-      }
-   ],
-   "updated":"2017-01-06T16:16:56.274Z",
-   "entities":[
-
-   ],
-   "language":"en",
-   "metadata":null,
-   "description":"A simple Conversation workspace that can detect three intents: #hello, #time, and #goodbye.",
-   "dialog_nodes":[
-      {
-         "go_to":null,
-         "output":{
-            "action":"display_time"
-         },
-         "parent":null,
-         "context":null,
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "metadata":null,
-         "conditions":"#time",
-         "description":null,
-         "dialog_node":"node_1_1479840416664",
-         "previous_sibling":"node_1_1479487905980"
+      "parent": null,
+      "context": null,
+      "metadata": null,
+      "next_step": null,
+      "conditions": "#goodbye",
+      "description": null,
+      "dialog_node": "node_1_1479487905980",
+      "previous_sibling": "node_1_1479323581900"
+    },
+    {
+      "type": "standard",
+      "title": null,
+      "output": {
+        "action": "display_time"
       },
-      {
-         "go_to":null,
-         "output":{
-            "text":"Good day to you."
-         },
-         "parent":null,
-         "context":null,
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "metadata":null,
-         "conditions":"#hello",
-         "description":null,
-         "dialog_node":"node_1_1479323581900",
-         "previous_sibling":"node_1_1480350999019"
+      "parent": null,
+      "context": null,
+      "metadata": null,
+      "next_step": null,
+      "conditions": "#time",
+      "description": null,
+      "dialog_node": "node_1_1479840416664",
+      "previous_sibling": "node_1_1479487905980"
+    },
+    {
+      "type": "standard",
+      "title": null,
+      "output": {
+        "text": "Good day to you."
       },
-      {
-         "go_to":null,
-         "output":{
-            "text":"Welcome to the Conversation example!"
-         },
-         "parent":null,
-         "context":null,
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "metadata":null,
-         "conditions":"conversation_start",
-         "description":null,
-         "dialog_node":"node_1_1480350999019",
-         "previous_sibling":null
+      "parent": null,
+      "context": null,
+      "metadata": null,
+      "next_step": null,
+      "conditions": "#hello",
+      "description": null,
+      "dialog_node": "node_1_1479323581900",
+      "previous_sibling": "node_1_1480350999019"
+    },
+    {
+      "type": "standard",
+      "title": null,
+      "output": {
+        "text": "Welcome to the Watson Assistant example!"
       },
-      {
-         "go_to":null,
-         "output":{
-            "text":{
-               "values":[
-                  "Sorry, I have no idea what you're talking about."
-               ]
-            }
-         },
-         "parent":null,
-         "context":null,
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:16:56.274Z",
-         "metadata":null,
-         "conditions":"anything_else",
-         "description":null,
-         "dialog_node":"node_2_1479323591143",
-         "previous_sibling":"node_1_1479840416664"
-      },
-      {
-         "go_to":null,
-         "output":{
-            "text":"OK! See you later.",
-            "action":"end_conversation"
-         },
-         "parent":null,
-         "context":null,
-         "created":"2017-01-06T16:15:57.864Z",
-         "updated":"2017-01-06T16:15:57.864Z",
-         "metadata":null,
-         "conditions":"#goodbye",
-         "description":null,
-         "dialog_node":"node_1_1479487905980",
-         "previous_sibling":"node_1_1479323581900"
-      }
-   ],
-   "workspace_id":"119d6ba3-f555-4a0d-b1e7-828e7c4dcf8a",
-   "counterexamples":[
-
-   ]
+      "parent": null,
+      "context": null,
+      "metadata": {},
+      "next_step": null,
+      "conditions": "conversation_start",
+      "description": null,
+      "dialog_node": "node_1_1480350999019",
+      "previous_sibling": null
+    }
+  ],
+  "workspace_id": "90b1fb79-9772-452a-b85a-adca9b0f978f",
+  "counterexamples": [],
+  "learning_opt_out": false
 }


### PR DESCRIPTION
This is a fresh export of the example workspace used by the "Building a client application" tutorial in the docs. The only substantive change is updating the response text to say "Watson Assistant" instead of "Conversation."