### PR TITLE
Travis CI: Lint for Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: python
+install: pip install flake8
+script: flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics


### PR DESCRIPTION
Travis testing would need to be enabled at:
* https://travis-ci.org/watson-developer-cloud/doc-tutorial-downloads