### PR TITLE
Fix for the text garbling after the migration to Watson Discovery 2.1.3 on CP4D

### DIFF
--- a/discovery-data/2.1.3/all-backup-restore.sh
+++ b/discovery-data/2.1.3/all-backup-restore.sh
@@ -4,10 +4,9 @@ set -e
 
 BACKUP_ARGS=""
 BACKUP_DIR="tmp"
-VERSION_FILE="tmp/version.txt"
+BACKUP_VERSION_FILE="tmp/version.txt"
 TMP_WORK_DIR="tmp/all_backup"
 SPLITE_DIR=./tmp_split_bakcup
-SCRIPT_VERSION="2.1.3"
 
 printUsage() {
   echo "Usage: $(basename ${0}) [command] [releaseName] [-f backupFile]"
@@ -21,6 +20,12 @@ fi
 SCRIPT_DIR=$(dirname $0)
 
 . ${SCRIPT_DIR}/lib/function.bash
+
+set_scripts_version
+export WD_VERSION=`get_version`
+brlog "INFO" "Watson Discovery Version: ${WD_VERSION}"
+validate_version
+
 
 COMMAND=$1
 shift
@@ -50,15 +55,6 @@ export RELEASE_NAME=${RELEASE_NAME}
 export BACKUP_ARGS=${BACKUP_ARGS}
 export SCRIPT_DIR=${SCRIPT_DIR}
 
-export WD_VERSION=`get_version`
-
-brlog "INFO" "Scripts Version: ${SCRIPT_VERSION}"
-brlog "INFO" "Watson Discovery Version: ${WD_VERSION}"
-
-if [ "${WD_VERSION}" != "${SCRIPT_VERSION}" ] ; then
-  brlog "ERROR" "Invalid script version. The version of scripts '${SCRIPT_VERSION}' is not valid for the version of Watson Doscovery '${WD_VERSION}' "
-  exit 1
-fi
 
 brlog "INFO" "Getting mc command for backup/restore of MinIO and ElasticSearch"
 rm -rf ${TMP_WORK_DIR}
@@ -96,7 +92,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   mkdir -p "${BACKUP_DIR}"
   run
   rm -rf ${TMP_WORK_DIR}
-  echo -n "${WD_VERSION}" > ${VERSION_FILE}
+  echo -n "${WD_VERSION}" > ${BACKUP_VERSION_FILE}
   brlog "INFO" "Archiving all backup files..."
   tar zcf "${BACKUP_FILE}" "${BACKUP_DIR}"
   brlog "INFO" "Verifying backup..."

--- a/discovery-data/2.1.3/etcd-backup-restore.sh
+++ b/discovery-data/2.1.3/etcd-backup-restore.sh
@@ -17,13 +17,8 @@ PG_SERVICE_FILE="${ETCD_BACKUP_DIR}/pg_service_name.txt"
 
 printUsage() {
   echo "Usage: $(basename ${0}) [command] [releaseName] [-f backupFile]"
-  echo "Env: WD_VERSION - The version of Watson Discovery. ex) '2.1.3'"
   exit 1
 }
-
-if [ $# -lt 2 -o ! -n "${WD_VERSION+UNDEF}" ] ; then
-  printUsage
-fi
 
 COMMAND=$1
 shift

--- a/discovery-data/2.1.3/lib/function.bash
+++ b/discovery-data/2.1.3/lib/function.bash
@@ -24,6 +24,35 @@ brlog(){
   fi
 }
 
+set_scripts_version(){
+  if [ -n "${SCRIPTS_VERSION+UNDEF}" ] ; then
+    return
+  fi
+  SCRIPT_VERSION_FILE="${SCRIPT_DIR}/version.txt"
+  if [ ! -e "${SCRIPT_VERSION_FILE}" ] ; then
+    brlog "INFO" "No version file."
+    return
+  fi
+
+  ORG_IFS=${IFS}
+  IFS=$'\n'
+  for line in `cat "${SCRIPT_VERSION_FILE}"`
+  do
+    brlog "INFO" "${line}"
+    if [[ ${line} == "Scripts Version:"* ]] ; then
+      export SCRIPT_VERSION="${line#*: }"
+    fi
+  done
+  IFS=${ORG_IFS}
+}
+
+validate_version(){
+  if [[ ${SCRIPT_VERSION} != ${WD_VERSION}* ]] ; then
+    brlog "ERROR" "Invalid script version. The version of scripts '${SCRIPT_VERSION}' is not valid for the version of Watson Doscovery '${WD_VERSION}' "
+    exit 1
+  fi
+}
+
 get_version(){
   if [ -n "`kubectl get pod ${KUBECTL_ARGS} -l "app.kubernetes.io/name=discovery,run=management"`" ] ; then
       echo "2.1.3"
@@ -35,8 +64,8 @@ get_version(){
 }
 
 get_backup_version(){
-  if [ -e "${VERSION_FILE}" ] ; then
-    cat "${VERSION_FILE}"
+  if [ -e "${BACKUP_VERSION_FILE}" ] ; then
+    cat "${BACKUP_VERSION_FILE}"
   else
     echo "2.1" # 2.1.2 or earlier
   fi

--- a/discovery-data/2.1.3/src/update-content-type.pgupdate
+++ b/discovery-data/2.1.3/src/update-content-type.pgupdate
@@ -1,0 +1,4 @@
+export PGUSER=${PGUSER:-${STKEEPER_PG_SU_USERNAME}} && \
+export PGPASSWORD=${PGPASSWORD:-`cat ${STKEEPER_PG_SU_PASSWORDFILE}`} && \
+export PGHOST=${PGHOST:-localhost} && \
+psql -d dadmin -c "UPDATE source_documents SET media_type = 'application/octet-stream' WHERE media_type = 'application/vnd.ms-excel'"

--- a/discovery-data/2.1.3/version.txt
+++ b/discovery-data/2.1.3/version.txt
@@ -1,0 +1,2 @@
+The Backup and Restore Scripts for the Watson Discovery on CP4D.
+Scripts Version: 2.1.3.1

--- a/discovery-data/2.1/version.txt
+++ b/discovery-data/2.1/version.txt
@@ -1,0 +1,2 @@
+The Backup and Restore Scripts for the Watson Discovery on CP4D.
+Scripts Version: 2.1.2.1


### PR DESCRIPTION
This PR will add some scripts to the backup and restore scripts of the Watson Discovery on CP4D. They will fix the text garbling in the CSV file after the migration to Watson Discovery 2.1.3. This also add the version file of the Backup Restore scripts.