### PR TITLE
Update the backup/restore scripts for Watson Discovery on CP4D.

### DIFF
--- a/discovery-data/2.1.3/lib/function.bash
+++ b/discovery-data/2.1.3/lib/function.bash
@@ -424,6 +424,7 @@ launch_migrator_job(){
   MINIO_CONFIGMAP=`kubectl get ${KUBECTL_ARGS} configmap -l release=${DATA_SOURCE_RELEASE_NAME},app.kubernetes.io/component=minio -o jsonpath="{.items[0].metadata.name}"`
   MINIO_SECRET=`kubectl ${KUBECTL_ARGS} get secret -l release=${DATA_SOURCE_RELEASE_NAME} -o jsonpath="{.items[*].metadata.name}" | tr -s '[[:space:]]' '\n' | grep minio`
   DISCO_SVC_ACCOUNT=`kubectl ${KUBECTL_ARGS} get serviceaccount -l release=${ADMIN_RELEASE_NAME} -o jsonpath="{.items[*].metadata.name}"`
+  SDU_SVC=`kubectl get ${KUBECTL_ARGS} configmap core-discovery-gateway -o jsonpath='{.data.SDU_SVC}'`
   NAMESPACE=${NAMESPACE:-`kubectl config view --minify --output 'jsonpath={..namespace}'`}
 
   sed -e "s/@namespace@/${NAMESPACE}/g" \
@@ -439,6 +440,7 @@ launch_migrator_job(){
     -e "s/@ck-secret@/${CK_SECRET}/g" \
     -e "s/@cpu-limit@/${MIGRATOR_CPU_LIMITS}/g" \
     -e "s/@memory-limit@/${MIGRATOR_MEMORY_LIMITS}/g" \
+    -e "s/@sdu-svc@/${SDU_SVC}/g" \
     "${MIGRATOR_JOB_TEMPLATE}" > "${MIGRATOR_JOB_FILE}"
 
   kubectl ${KUBECTL_ARGS} apply -f "${MIGRATOR_JOB_FILE}"

--- a/discovery-data/2.1.3/src/migrator-job-template.yml
+++ b/discovery-data/2.1.3/src/migrator-job-template.yml
@@ -46,6 +46,10 @@ spec:
           value: "100"
         - name: MIGRATOR_MAX_HEAP
           value: "@max-heap@"
+        - name: SDU_SERVER_ENDPOINT
+          value: "https://@sdu-svc@/api/v3"
+        - name: INITIALIZE_DB_WITH_LIQUIBASE
+          value: "true"
         - name: PGHOST
           valueFrom:
             configMapKeyRef:


### PR DESCRIPTION
Update the backup/restore scripts for Watson Discovery on CP4D 2.1.3 or later. It includes some miner fixes:
- Make a temporary MinIO configuration to avoid conflicts, especially conflicts with the backup/restore of Watson Knowledge Studio.
- Add some configuration of the migrator for the future release.