### PR TITLE
Fix scripts for Watson Discovery 2.2.1 on CP4D

### DIFF
--- a/discovery-data/2.2.0/lib/function.bash
+++ b/discovery-data/2.2.0/lib/function.bash
@@ -440,7 +440,7 @@ get_migrator_tag(){
 }
 
 launch_migrator_job(){
-  MIGRATOR_TAG=${MIGRATOR_TAG:-12.0.6-2031}
+  MIGRATOR_TAG="${MIGRATOR_TAG:-`get_migrator_tag`}"
   MIGRATOR_JOB_NAME="wd-migrator-job"
   MIGRATOR_JOB_TEMPLATE="${SCRIPT_DIR}/src/migrator-job-template.yml"
   MIGRATOR_JOB_FILE="${SCRIPT_DIR}/src/migrator-job.yml"


### PR DESCRIPTION
This PR includes fix for Watson Discovery 2.2.1 on CP4D
- Fix: Backup/Restore scripts set wrong migrator tag on WD 2.2.1.