### PR TITLE
Fix scripts for Watson Discovery 2.2.1 on CP4D

### DIFF
--- a/discovery-data/2.2.0/lib/function.bash
+++ b/discovery-data/2.2.0/lib/function.bash
@@ -413,7 +413,11 @@ quiesce(){
   brlog "INFO" "Quiescing"
   echo
 
-  trap "unquiesce; brlog 'ERROR' 'Backup/Restore failed.'" 0 1 2 3 15
+  if [ "$COMMAND" = "restore" ] ; then
+    trap "brlog 'ERROR' 'Error occur while running scripts.' ; unquiesce; ./post-restore.sh ${TENANT_NAME}; brlog 'ERROR' 'Backup/Restore failed.'" 0 1 2 3 15
+  else
+    trap "unquiesce; brlog 'ERROR' 'Backup/Restore failed.'" 0 1 2 3 15
+  fi
   oc patch wd ${TENANT_NAME} --type merge --patch '{"spec": {"shared": {"quiesce": {"enabled": true}}}}'
 
   # Check there are no DOCPROC application in yarn cue.

--- a/discovery-data/2.2.0/post-restore.sh
+++ b/discovery-data/2.2.0/post-restore.sh
@@ -75,7 +75,12 @@ for tenants_file in `ls -t tmp_wd_tenants_*.txt` ; do
     fetch_cmd_result ${PG_POD} 'export PGUSER=${STKEEPER_PG_SU_USERNAME} && \
       export PGPASSWORD=${STKEEPER_PG_SU_PASSWORD} && \
       export PGHOST=${HOSTNAME} && \
-      if ! psql -d dadmin -t -c "SELECT COUNT (*) FROM tenants;" | grep "1" > /dev/null ; then psql -d dadmin -c "COPY tenants FROM '"'"'/tmp/tenants'"'"'" ; else echo "COPY" ; fi&& \
+      if ! psql -d dadmin -t -c "SELECT * FROM tenants;" | grep "default" > /dev/null ; then \
+        psql -d dadmin -c "TRUNCATE tenants" && \
+        psql -d dadmin -c "COPY tenants FROM '"'"'/tmp/tenants'"'"'" ;\
+      else\
+        echo "COPY" ;\
+      fi&& \
       rm -f /tmp/tenants' ${OC_ARGS} | grep COPY >& /dev/null
   fi
 done

--- a/discovery-data/2.2.0/run-postgres-config-job.sh
+++ b/discovery-data/2.2.0/run-postgres-config-job.sh
@@ -30,9 +30,7 @@ PG_JOB_FILE="${SCRIPT_DIR}/src/postgres-config-job.yml"
 
 brlog "INFO" "Start postgresql configuration"
 
-PG_CONFIG_REPO="`oc get ${OC_ARGS} wd ${TENANT_NAME} -o jsonpath='{.spec.shared.dockerRegistryPrefix}'`configure-postgres"
-PG_CONFIG_TAG=${PG_CONFIG_TAG:-20201105-032403-878-1162f9e3}
-PG_CONFIG_IMAGE="${PG_CONFIG_REPO}:${PG_CONFIG_TAG}"
+PG_CONFIG_IMAGE=`oc ${OC_ARGS} get deploy -o jsonpath="{..image}" |tr -s '[[:space:]]' '\n' | sort | uniq | grep training-data-crud | sed -e "s/training-data-crud/configure-postgres/g"`
 PG_CONFIGMAP=`oc get ${OC_ARGS} configmap -l tenant=${TENANT_NAME},app.kubernetes.io/component=postgres-cxn -o jsonpath="{.items[0].metadata.name}"`
 PG_SECRET=`oc ${OC_ARGS} get secret -l tenant=${TENANT_NAME},cr=${TENANT_NAME}-discovery-postgres -o jsonpath="{.items[*].metadata.name}"`
 NAMESPACE=${NAMESPACE:-`oc config view --minify --output 'jsonpath={..namespace}'`}

--- a/discovery-data/2.2.0/version.txt
+++ b/discovery-data/2.2.0/version.txt
@@ -1,2 +1,2 @@
 The Backup and Restore Scripts for the Watson Discovery on CP4D.
-Scripts Version: 2.2.1.1
+Scripts Version: 2.2.1.2

--- a/discovery-data/2.2.0/version.txt
+++ b/discovery-data/2.2.0/version.txt
@@ -1,2 +1,2 @@
 The Backup and Restore Scripts for the Watson Discovery on CP4D.
-Scripts Version: 2.2.1.0
+Scripts Version: 2.2.1.1


### PR DESCRIPTION
This PR includes fix for Watson Discovery 2.2.1 on CP4D
- Fix: Backup/Restore scripts set wrong configure-postgresql tag.
- Fix: Wrong tenant record is inserted after restore.