### PR TITLE
Fix backup and restore scripts for Watson Discovery on CP4D

### DIFF
--- a/discovery-data/2.1.3/elastic-backup-restore.sh
+++ b/discovery-data/2.1.3/elastic-backup-restore.sh
@@ -103,7 +103,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   curl -XPUT -s -k -u ${ELASTIC_USER}:${ELASTIC_PASSWORD} "${ELASTIC_ENDPOINT}/_snapshot/'${ELASTIC_REPO}'/'${ELASTIC_SNAPSHOT}'?wait_for_completion=true&master_timeout='${ELASTIC_REQUEST_TIMEOUT}'" -H "Content-Type: application/json" -d'"'"'{"indices": "*","ignore_unavailable": true,"include_global_state": false}'"'"
   wait_cmd ${ELASTIC_POD} "curl -XPUT -s -k -u" ${KUBECTL_ARGS}
   echo
-  brlog "INFO" "Transfering snapshot from MinIO"
+  brlog "INFO" "Transferring snapshot from MinIO"
   start_minio_port_forward
   ${MC} ${MC_OPTS[@]} mirror wdminio/${ELASTIC_BACKUP_BUCKET} ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET} > /dev/null
   stop_minio_port_forward
@@ -145,7 +145,7 @@ if [ ${COMMAND} = 'restore' ] ; then
   brlog "INFO" "Extracting Archive..."
   mkdir -p ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
   tar ${ELASTIC_TAR_OPTIONS[@]} -xf ${BACKUP_FILE} -C ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
-  brlog "INFO" "Transfering data to MinIO..."
+  brlog "INFO" "Transferring data to MinIO..."
   start_minio_port_forward
   ${MC} ${MC_OPTS[@]} config host add wdminio ${MINIO_ENDPOINT_URL} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} > /dev/null
   ${MC} ${MC_OPTS[@]} rm --recursive --force --dangerous wdminio/${ELASTIC_BACKUP_BUCKET}/ > /dev/null

--- a/discovery-data/2.1.3/etcd-backup-restore.sh
+++ b/discovery-data/2.1.3/etcd-backup-restore.sh
@@ -67,7 +67,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   echo -n '${PG_SERVICE_NAME}' > ${PG_SERVICE_FILE}"
   wait_cmd ${ETCD_POD} "etcdctl --insecure-skip-tls-verify=true" ${KUBECTL_ARGS}
   if "${ARCHIVE_ON_LOCAL}" ; then 
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     mkdir -p "`dirname ${TMP_WORK_DIR}${ETCD_BACKUP_DIR}`"
     kube_cp_to_local -r ${ETCD_POD} "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}" "${ETCD_BACKUP_DIR}" ${KUBECTL_ARGS}
     kubectl ${KUBECTL_ARGS} exec ${ETCD_POD} -- bash -c "rm -rf ${ETCD_BACKUP_DIR}"
@@ -105,7 +105,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     brlog "INFO" "Extracting archive"
     mkdir -p "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}"
     tar ${ETCD_TAR_OPTIONS[@]} -xf ${BACKUP_FILE} -C "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}"
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     kube_cp_from_local -r ${ETCD_POD} "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}" "${ETCD_BACKUP_DIR}" ${KUBECTL_ARGS}
   else
     brlog "INFO" "Transferting archive..."

--- a/discovery-data/2.1.3/hdp-backup-restore.sh
+++ b/discovery-data/2.1.3/hdp-backup-restore.sh
@@ -68,7 +68,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     exit 1
   fi
   brlog "INFO" "Start restore hadoop: ${BACKUP_FILE}"
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_from_local ${HDP_POD} "${BACKUP_FILE}" "${HDP_BACKUP}" ${KUBECTL_ARGS} -c hdp-worker
   brlog "INFO" "Extracting archive..."
   kubectl exec -c hdp-worker ${HDP_POD} ${KUBECTL_ARGS} -- bash -c "cd /tmp && \

--- a/discovery-data/2.1.3/migrate-box-credential.sh
+++ b/discovery-data/2.1.3/migrate-box-credential.sh
@@ -91,7 +91,7 @@ if [ "${CMD}" = "migrate" ] ; then
   MIGRATION_FILES=`runPythonScripts ${GATEWAY_POD} ${LIST_FILES_SCRIPT} /tmp/${ETCD_SNAPSHOT_FILE}`
   tar zcf ${TMP_WORK_DIR}/${USER_DATA_ARCHIVE} -C ${USER_DATA_DIR} ${MIGRATION_FILES}
 
-  brlog "INFO" "Transfering migration files..."
+  brlog "INFO" "Transferring migration files..."
   kubectl cp ${KUBECTL_ARGS} "${USER_JSON_MAPPING}" ${GATEWAY_POD}:/tmp/${BOX_JSON_MAPPING}
   kubectl cp ${KUBECTL_ARGS} ${TMP_WORK_DIR}/${USER_DATA_ARCHIVE} ${GATEWAY_POD}:/tmp/${USER_DATA_ARCHIVE}
 

--- a/discovery-data/2.1.3/migrate-crawler-jar.sh
+++ b/discovery-data/2.1.3/migrate-crawler-jar.sh
@@ -68,7 +68,7 @@ kubectl cp ${KUBECTL_ARGS} ${TMP_WORK_DIR}/${ETCD_SNAPSHOT_FILE} ${GATEWAY_POD}:
 MIGRATION_FILES=`runPythonScripts ${GATEWAY_POD} ${LIST_FILES_SCRIPT} /tmp/${ETCD_SNAPSHOT_FILE}`
 tar zcf ${TMP_WORK_DIR}/${USER_DATA_ARCHIVE} -C ${USER_DATA_DIR} ${MIGRATION_FILES}
 
-brlog "INFO" "Transfering the migration files"
+brlog "INFO" "Transferring the migration files"
 kubectl cp ${KUBECTL_ARGS} ${TMP_WORK_DIR}/${USER_DATA_ARCHIVE} ${GATEWAY_POD}:/tmp/${USER_DATA_ARCHIVE}
 
 kubectl exec ${KUBECTL_ARGS} ${GATEWAY_POD} -- bash -c "mkdir -p /tmp/mnt && tar xf /tmp/${USER_DATA_ARCHIVE} -C /tmp/mnt"

--- a/discovery-data/2.1.3/postgresql-backup-restore.sh
+++ b/discovery-data/2.1.3/postgresql-backup-restore.sh
@@ -82,7 +82,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   touch /tmp/'${PG_BACKUP_DIR}'/version_'${PG_SCRIPT_VERSION}
   wait_cmd ${PG_POD} "pg_dump" ${KUBECTL_ARGS}
   if "${ARCHIVE_ON_LOCAL}" ; then 
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     kube_cp_to_local -r ${PG_POD} "${TMP_WORK_DIR}/${PG_BACKUP_DIR}" "/tmp/${PG_BACKUP_DIR}" ${KUBECTL_ARGS}
     kubectl ${KUBECTL_ARGS} exec ${PG_POD} -- bash -c "rm -rf /tmp/${PG_BACKUP_DIR}"
     brlog "INFO" "Archiving data"
@@ -153,7 +153,7 @@ if [ ${COMMAND} = 'restore' ] ; then
   if "${ARCHIVE_ON_LOCAL}" ; then
     brlog "INFO" "Extracting archive"
     tar ${PG_TAR_OPTIONS[@]} -xf ${BACKUP_FILE} -C ${TMP_WORK_DIR}
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     kube_cp_from_local -r ${PG_POD} "${TMP_WORK_DIR}/${PG_BACKUP_DIR}" "/tmp/${PG_BACKUP_DIR}" ${KUBECTL_ARGS}
   else
     brlog "INFO" "Transferting archive..."

--- a/discovery-data/2.1/elastic-backup-restore.sh
+++ b/discovery-data/2.1/elastic-backup-restore.sh
@@ -68,7 +68,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   kubectl exec ${ELASTIC_POD} ${KUBECTL_ARGS} --  bash -c 'cd ${ELASTIC_BACKUP_DIR} && \
   tar czf /tmp/'${ELASTIC_BACKUP}' ./*'
   wait_cmd ${ELASTIC_POD} "tar czf" ${KUBECTL_ARGS}
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_to_local ${ELASTIC_POD} "${BACKUP_FILE}" "/tmp/${ELASTIC_BACKUP}" ${KUBECTL_ARGS}
   brlog "INFO" "Clean up snapshot..."
   kubectl exec ${ELASTIC_POD} ${KUBECTL_ARGS} --  bash -c 'if [[ ! -v ES_PORT ]] ; then if [ -d "/opt/tls/elastic" ] ; then export ES_PORT=9100 ; else export ES_PORT=9200 ; fi ; fi && \
@@ -96,7 +96,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     echo
     exit 1
   fi
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_from_local ${ELASTIC_POD} "${BACKUP_FILE}" "/tmp/${ELASTIC_BACKUP}" ${KUBECTL_ARGS}
   brlog "INFO" "Extracting archive..."
   kubectl ${KUBECTL_ARGS} exec ${ELASTIC_POD} -- bash -c 'cd ${ELASTIC_BACKUP_DIR} && \

--- a/discovery-data/2.1/etcd-backup-restore.sh
+++ b/discovery-data/2.1/etcd-backup-restore.sh
@@ -69,7 +69,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   echo -n '${PG_SERVICE_NAME}' > ${PG_SERVICE_FILE} && \
   tar zcf ${ETCD_BACKUP} -C ${ETCD_BACKUP_DIR} ."
   wait_cmd ${ETCD_POD} "tar zcf" ${KUBECTL_ARGS}
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_to_local ${ETCD_POD} "${BACKUP_FILE}" "${ETCD_BACKUP}" ${KUBECTL_ARGS}
   kubectl ${KUBECTL_ARGS} exec ${ETCD_POD} --  bash -c "rm -rf ${ETCD_BACKUP_DIR} ${ETCD_BACKUP}"
   brlog "INFO" "Verifying backup..."
@@ -94,7 +94,7 @@ if [ ${COMMAND} = 'restore' ] ; then
   ETCD_POD=`kubectl get pods ${KUBECTL_ARGS} -o jsonpath="{.items[0].metadata.name}" -l release=${RELEASE_NAME},helm.sh/chart=etcd`
   REPLACE_SVC_STRING="-watson-discovery-postgresql"
   brlog "INFO" "Start restore etcd: ${BACKUP_FILE}"
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_from_local ${ETCD_POD} "${BACKUP_FILE}" "${ETCD_BACKUP}" ${KUBECTL_ARGS}
   brlog "INFO" "Restoring data..."
   kubectl ${KUBECTL_ARGS} exec ${ETCD_POD} -- bash -c 'export ETCDCTL_API=3 && \

--- a/discovery-data/2.1/hdp-backup-restore.sh
+++ b/discovery-data/2.1/hdp-backup-restore.sh
@@ -53,7 +53,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   kubectl exec ${HDP_POD} ${KUBECTL_ARGS} --  bash -c "cd /tmp && \
   tar zcf ${HDP_BACKUP} ${HDP_BACKUP_DIR}"
   wait_cmd ${HDP_POD} "tar zcf" ${KUBECTL_ARGS}
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_to_local ${HDP_POD} "${BACKUP_FILE}" "${HDP_BACKUP}" ${KUBECTL_ARGS}
   kubectl exec ${HDP_POD} ${KUBECTL_ARGS} -- bash -c "rm -rf ${HDP_BACKUP} /tmp/${HDP_BACKUP_DIR}"
   brlog "INFO" "Verifying backup..."
@@ -76,7 +76,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     exit 1
   fi
   brlog "INFO" "Start restore hadoop: ${BACKUP_FILE}"
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_from_local ${HDP_POD} "${BACKUP_FILE}" "${HDP_BACKUP}" ${KUBECTL_ARGS}
   brlog "INFO" "Extracting data..."
   kubectl exec ${HDP_POD} ${KUBECTL_ARGS} -- bash -c "cd /tmp && \

--- a/discovery-data/2.1/postgresql-backup-restore.sh
+++ b/discovery-data/2.1/postgresql-backup-restore.sh
@@ -54,7 +54,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   touch /tmp/'${PG_BACKUP_DIR}'/version_'${BACKUP_VERSION}' && \
   tar zcf '${PG_BACKUP}' -C /tmp '${PG_BACKUP_DIR}
   wait_cmd ${PG_POD} "tar zcf" ${KUBECTL_ARGS}
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_to_local ${PG_POD} "${BACKUP_FILE}" "${PG_BACKUP}" ${KUBECTL_ARGS}
   kubectl ${KUBECTL_ARGS} exec ${PG_POD} -- bash -c "rm -rf /tmp/${PG_BACKUP_DIR} ${PG_BACKUP}"
   brlog "INFO" "Verifying backup..."
@@ -122,7 +122,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     fi
   done
   brlog "INFO" "Start restore postgresql: ${BACKUP_FILE}"
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_from_local ${PG_POD} "${BACKUP_FILE}" "${PG_BACKUP}" ${KUBECTL_ARGS}
   brlog "INFO" "Restoring data..."
   kubectl exec ${KUBECTL_ARGS} ${PG_POD} -- bash -c 'export PGUSER=${PGUSER:-${STKEEPER_PG_SU_USERNAME}} && \

--- a/discovery-data/2.1/wddata-backup-restore.sh
+++ b/discovery-data/2.1/wddata-backup-restore.sh
@@ -50,7 +50,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   kubectl exec ${GATEWAY_POD} ${KUBECTL_ARGS} --  bash -c 'rm -f /tmp/'${WDDATA_BACKUP}' && \
   tar zcf /tmp/'${WDDATA_BACKUP}' --exclude ".nfs*" --exclude wexdata/logs --exclude "wexdata/zing/data/crawler/*/temp" wexdata/* ; code=$?; if [ $code -ne 0 -a $code -ne 1 ] ; then echo "Fatal Error"; exit $code; fi'
   wait_cmd ${GATEWAY_POD} "tar zcf" ${KUBECTL_ARGS}
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_to_local ${GATEWAY_POD} "${BACKUP_FILE}" "/tmp/${WDDATA_BACKUP}" ${KUBECTL_ARGS}
   kubectl exec ${GATEWAY_POD} ${KUBECTL_ARGS} --  bash -c "rm -f /tmp/${WDDATA_BACKUP}"
   brlog "INFO" "Verifying backup..."
@@ -73,7 +73,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     exit 1
   fi
   brlog "INFO" "Start restore wddata: ${BACKUP_FILE}"
-  brlog "INFO" "Transfering archive..."
+  brlog "INFO" "Transferring archive..."
   kube_cp_from_local ${GATEWAY_POD} "${BACKUP_FILE}" "/tmp/${WDDATA_BACKUP}" ${KUBECTL_ARGS}
   brlog "INFO" "Restoring data..."
   kubectl exec ${GATEWAY_POD} ${KUBECTL_ARGS} -- bash -c "tar xf /tmp/${WDDATA_BACKUP} --exclude *.lck ; rm -f /tmp/${WDDATA_BACKUP}"

--- a/discovery-data/2.2.0/elastic-backup-restore.sh
+++ b/discovery-data/2.2.0/elastic-backup-restore.sh
@@ -128,7 +128,7 @@ if "${BACKUP_RESTORE_IN_POD}" ; then
   oc ${OC_ARGS} cp "${SCRIPT_DIR}/src/${ELASTIC_BACKUP_RESTORE_SCRIPTS}" ${POD}:${BACKUP_RESTORE_DIR_IN_POD}/
 
   if [ "${COMMAND}" = "restore" ] ; then
-    brlog "INFO" "Transfering backup data"
+    brlog "INFO" "Transferring backup data"
     kube_cp_from_local ${POD} "${BACKUP_FILE}" "${BACKUP_RESTORE_DIR_IN_POD}/${ELASTIC_BACKUP}" ${OC_ARGS}
   fi
   oc ${OC_ARGS} exec ${POD} -- touch /tmp/wexdata_copied
@@ -144,7 +144,7 @@ if "${BACKUP_RESTORE_IN_POD}" ; then
     fi
   done
   if [ "${COMMAND}" = "backup" ] ; then
-    brlog "INFO" "Transfering backup data"
+    brlog "INFO" "Transferring backup data"
     kube_cp_to_local ${POD} "${BACKUP_FILE}" "${BACKUP_RESTORE_DIR_IN_POD}/${ELASTIC_BACKUP}" ${OC_ARGS}
     if "${VERIFY_DATASTORE_ARCHIVE}" && brlog "INFO" "Verifying backup archive" && ! tar ${ELASTIC_TAR_OPTIONS[@]} -tf ${BACKUP_FILE} &> /dev/null ; then
       brlog "ERROR" "Backup file is broken, or does not exist."
@@ -193,7 +193,7 @@ if [ ${COMMAND} = 'backup' ] ; then
     if [ "${snapshot_status}" = "SUCCESS" ] ; then
       brlog "INFO" "Snapshot successfully finished."
       run_cmd_in_pod ${ELASTIC_POD} 'curl -s -k -u ${ELASTIC_USER}:${ELASTIC_PASSWORD} "${ELASTIC_ENDPOINT}/_snapshot/'${ELASTIC_REPO}'/'${ELASTIC_SNAPSHOT}'" | jq -r ".snapshots[0]"' ${OC_ARGS} -c elasticsearch
-      brlog "INFO" "Transfering snapshot from MinIO"
+      brlog "INFO" "Transferring snapshot from MinIO"
       cat << EOF >> "${BACKUP_RESTORE_LOG_DIR}/${CURRENT_COMPONENT}.log"
 ===================================================
 ${MC} ${MC_OPTS[@]} mirror wdminio/${ELASTIC_BACKUP_BUCKET} ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}"
@@ -257,7 +257,7 @@ if [ ${COMMAND} = 'restore' ] ; then
   brlog "INFO" "Extracting Archive..."
   mkdir -p ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
   tar ${ELASTIC_TAR_OPTIONS[@]} -xf ${BACKUP_FILE} -C ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
-  brlog "INFO" "Transfering data to MinIO..."
+  brlog "INFO" "Transferring data to MinIO..."
   start_minio_port_forward
   ${MC} ${MC_OPTS[@]} config host add wdminio ${MINIO_ENDPOINT_URL} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} > /dev/null
   if [ -n "`${MC} ${MC_OPTS[@]} ls wdminio/${ELASTIC_BACKUP_BUCKET}/`" ] ; then

--- a/discovery-data/2.2.0/etcd-backup-restore.sh
+++ b/discovery-data/2.2.0/etcd-backup-restore.sh
@@ -71,7 +71,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   etcdctl get --prefix '/' -w fields > ${ETCD_BACKUP_FILE}" ${OC_ARGS}
 
   if "${ARCHIVE_ON_LOCAL}" ; then 
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     mkdir -p "`dirname ${TMP_WORK_DIR}${ETCD_BACKUP_DIR}`"
     kube_cp_to_local -r ${ETCD_POD} "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}" "${ETCD_BACKUP_DIR}" ${OC_ARGS}
     oc ${OC_ARGS} exec ${ETCD_POD} -- bash -c "rm -rf ${ETCD_BACKUP_DIR}"
@@ -109,7 +109,7 @@ if [ ${COMMAND} = 'restore' ] ; then
     brlog "INFO" "Extracting archive"
     mkdir -p "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}"
     tar ${ETCD_TAR_OPTIONS[@]} -xf ${BACKUP_FILE} -C "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}"
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     kube_cp_from_local -r ${ETCD_POD} "${TMP_WORK_DIR}${ETCD_BACKUP_DIR}" "${ETCD_BACKUP_DIR}" ${OC_ARGS}
   else
     brlog "INFO" "Transferting archive..."

--- a/discovery-data/2.2.0/minio-backup-restore.sh
+++ b/discovery-data/2.2.0/minio-backup-restore.sh
@@ -117,7 +117,7 @@ if "${BACKUP_RESTORE_IN_POD}" ; then
   oc ${OC_ARGS} cp "${SCRIPT_DIR}/src/${MINIO_BACKUP_RESTORE_SCRIPTS}" ${POD}:${BACKUP_RESTORE_DIR_IN_POD}/
 
   if [ ${COMMAND} == "restore" ] ; then
-    brlog "INFO" "Transfering backup data"
+    brlog "INFO" "Transferring backup data"
     kube_cp_from_local ${POD} "${BACKUP_FILE}" "${BACKUP_RESTORE_DIR_IN_POD}/${MINIO_BACKUP}" ${OC_ARGS}
   fi
   oc ${OC_ARGS} exec ${POD} -- touch /tmp/wexdata_copied
@@ -133,7 +133,7 @@ if "${BACKUP_RESTORE_IN_POD}" ; then
     fi
   done
   if [ "${COMMAND}" = "backup" ] ; then
-    brlog "INFO" "Transfering backup data"
+    brlog "INFO" "Transferring backup data"
     kube_cp_to_local ${POD} "${BACKUP_FILE}" "${BACKUP_RESTORE_DIR_IN_POD}/${MINIO_BACKUP}" ${OC_ARGS}
     if "${VERIFY_DATASTORE_ARCHIVE}" && brlog "INFO" "Verifying backup archive" && ! tar ${ELASTIC_TAR_OPTIONS[@]} -tf ${BACKUP_FILE} &> /dev/null ; then
       brlog "ERROR" "Backup file is broken, or does not exist."

--- a/discovery-data/2.2.0/postgresql-backup-restore.sh
+++ b/discovery-data/2.2.0/postgresql-backup-restore.sh
@@ -81,7 +81,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   for DATABASE in $( psql -l | grep ${PGUSER} | cut -d "|" -f 1 | grep -v -e template -e postgres -e "^\s*$"); do pg_dump ${DATABASE} > '${PG_BACKUP_PREFIX}'${DATABASE}'${PG_BACKUP_SUFFIX}'; done && \
   touch /tmp/'${PG_BACKUP_DIR}'/version_'${PG_SCRIPT_VERSION} ${OC_ARGS}
   if "${ARCHIVE_ON_LOCAL}" ; then 
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     kube_cp_to_local -r ${PG_POD} "${TMP_WORK_DIR}/${PG_BACKUP_DIR}" "/tmp/${PG_BACKUP_DIR}" ${OC_ARGS}
     oc ${OC_ARGS} exec ${PG_POD} -- bash -c "rm -rf /tmp/${PG_BACKUP_DIR}"
     brlog "INFO" "Archiving data"
@@ -131,7 +131,7 @@ if [ ${COMMAND} = 'restore' ] ; then
   if "${ARCHIVE_ON_LOCAL}" ; then
     brlog "INFO" "Extracting archive"
     tar ${PG_TAR_OPTIONS[@]} -xf ${BACKUP_FILE} -C ${TMP_WORK_DIR}
-    brlog "INFO" "Transfering backup files"
+    brlog "INFO" "Transferring backup files"
     kube_cp_from_local -r ${PG_POD} "${TMP_WORK_DIR}/${PG_BACKUP_DIR}" "/tmp/${PG_BACKUP_DIR}" ${OC_ARGS}
   else
     brlog "INFO" "Transferting archive..."

--- a/discovery-data/2.2.0/src/elastic-backup-restore-in-pod.sh
+++ b/discovery-data/2.2.0/src/elastic-backup-restore-in-pod.sh
@@ -24,6 +24,10 @@ ELASTIC_LOG="${TMP_WORK_DIR}/elastic.log"
 
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir ${MINIO_CONFIG_DIR} --insecure)
+MC_MIRROR_OPTS=( "" )
+if "${DISABLE_MC_MULTIPART:-true}" ; then
+  MC_MIRROR_OPTS=( "${MC_MIRROR_OPTS[@]}" --disable-multipart )
+fi
 MC=mc
 
 if [ -n "${ELASTIC_ARCHIVE_OPTION}" ] ; then
@@ -57,7 +61,7 @@ if [ "${COMMAND}" = "backup" ] ; then
 ${MC} ${MC_OPTS[@]} mirror wdminio/${ELASTIC_BACKUP_BUCKET} ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}"
 ===================================================
 EOF
-        ${MC} ${MC_OPTS[@]} mirror wdminio/${ELASTIC_BACKUP_BUCKET} ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET} &>> "${ELASTIC_LOG}"
+        ${MC} ${MC_OPTS[@]} mirror ${MC_MIRROR_OPTS[@]} wdminio/${ELASTIC_BACKUP_BUCKET} ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET} &>> "${ELASTIC_LOG}"
         RC=$?
         echo "RC=${RC}" >> "${ELASTIC_LOG}"
         if [ $RC -eq 0 ] ; then
@@ -109,7 +113,7 @@ elif [ "${COMMAND}" = "restore" ] ; then
 ${MC} ${MC_OPTS[@]} mirror --debug ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET} wdminio/${ELASTIC_BACKUP_BUCKET}
 ===================================================
 EOF
-    ${MC} ${MC_OPTS[@]} mirror ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET} wdminio/${ELASTIC_BACKUP_BUCKET} &>> "${ELASTIC_LOG}"
+    ${MC} ${MC_OPTS[@]} mirror ${MC_MIRROR_OPTS[@]} ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET} wdminio/${ELASTIC_BACKUP_BUCKET} &>> "${ELASTIC_LOG}"
     RC=$?
     echo "RC=${RC}" >> "${ELASTIC_LOG}"
     if [ $RC -eq 0 ] ; then

--- a/discovery-data/2.2.0/src/elastic-backup-restore-in-pod.sh
+++ b/discovery-data/2.2.0/src/elastic-backup-restore-in-pod.sh
@@ -53,7 +53,7 @@ if [ "${COMMAND}" = "backup" ] ; then
     if [ "${snapshot_status}" = "SUCCESS" ] ; then
       brlog "INFO" "Snapshot successfully finished."
       curl -s -k -u ${ELASTIC_USER}:${ELASTIC_PASSWORD} "${ELASTIC_ENDPOINT}/_snapshot/${ELASTIC_REPO}/${ELASTIC_SNAPSHOT}" | jq -r ".snapshots[0]"
-      brlog "INFO" "Transfering snapshot from MinIO"
+      brlog "INFO" "Transferring snapshot from MinIO"
       while true;
       do
         cat << EOF >> "${ELASTIC_LOG}"
@@ -101,7 +101,7 @@ elif [ "${COMMAND}" = "restore" ] ; then
   mkdir -p ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
   tar ${ELASTIC_TAR_OPTIONS[@]} -xf ${ELASTIC_BACKUP} -C ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
   rm -f ${ELASTIC_BACKUP}
-  brlog "INFO" "Transfering data to MinIO..."
+  brlog "INFO" "Transferring data to MinIO..."
   ${MC} ${MC_OPTS[@]} config host add wdminio ${MINIO_ENDPOINT_URL} ${MINIO_ACCESS_KEY} ${MINIO_SECRET_KEY} > /dev/null
   if [ -n "`${MC} ${MC_OPTS[@]} ls wdminio/${ELASTIC_BACKUP_BUCKET}/`" ] ; then
     ${MC} ${MC_OPTS[@]} rm --recursive --force --dangerous wdminio/${ELASTIC_BACKUP_BUCKET}/ > /dev/null

--- a/discovery-data/2.2.0/src/minio-backup-restore-in-pod.sh
+++ b/discovery-data/2.2.0/src/minio-backup-restore-in-pod.sh
@@ -37,6 +37,10 @@ mkdir -p ${TMP_WORK_DIR}/.mc
 MC=mc
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir ${MINIO_CONFIG_DIR} --insecure)
+MC_MIRROR_OPTS=( "" )
+if "${DISABLE_MC_MULTIPART:-true}" ; then
+  MC_MIRROR_OPTS=( "${MC_MIRROR_OPTS[@]}" --disable-multipart )
+fi
 
 # backup
 if [ "${COMMAND}" = "backup" ] ; then
@@ -60,7 +64,7 @@ if [ "${COMMAND}" = "backup" ] ; then
     set +e
     while true;
     do
-      ${MC} ${MC_OPTS[@]} --quiet mirror ${EXTRA_MC_MIRROR_COMMAND} wdminio/${bucket} ${MINIO_BACKUP_DIR}/${bucket} 2>&1
+      ${MC} ${MC_OPTS[@]} --quiet mirror ${MC_MIRROR_OPTS[@]} ${EXTRA_MC_MIRROR_COMMAND} wdminio/${bucket} ${MINIO_BACKUP_DIR}/${bucket} 2>&1
       RC=$?
       echo "RC=${RC}"
       if [ $RC -eq 0 ] ; then
@@ -102,7 +106,7 @@ if [ "${COMMAND}" = "restore" ] ; then
       set +e
       while true;
       do
-        ${MC} ${MC_OPTS[@]} --quiet mirror ${TMP_WORK_DIR}/${MINIO_BACKUP_DIR}/${bucket} wdminio/${bucket} 2>&1
+        ${MC} ${MC_OPTS[@]} --quiet mirror ${MC_MIRROR_OPTS[@]} ${TMP_WORK_DIR}/${MINIO_BACKUP_DIR}/${bucket} wdminio/${bucket} 2>&1
         RC=$?
         echo "RC=${RC}"
         if [ $RC -eq 0 ] ; then

--- a/discovery-data/2.2.0/src/minio-client-job-template.yml
+++ b/discovery-data/2.2.0/src/minio-client-job-template.yml
@@ -115,6 +115,4 @@ spec:
             - mountPath: /tmp/backup-restore-workspace
               name: backup-restore-workspace
       volumes:
-        - name: backup-restore-workspace
-          emptyDir: {}
       terminationGracePeriodSeconds: 0

--- a/discovery-data/2.2.0/version.txt
+++ b/discovery-data/2.2.0/version.txt
@@ -1,2 +1,2 @@
 The Backup and Restore Scripts for the Watson Discovery on CP4D.
-Scripts Version: 2.2.1.3
+Scripts Version: 2.2.1.4


### PR DESCRIPTION
Fix backup and restore scripts for Watson Discovery on CP4D 2.2.0 or later.
This includes:
- Fix out of memory issue of MinIO client.
- Fix a issue that restoring ElasticSearch or MinIO get stuck while getting logs of pod.
- Stop scripts on failure in transferring data with MinIO client.
- Add option that mount PVC on job for backup/restore ElasticSearch or MinIO.
- Modify help messages.