### PR TITLE
FIX: Return only WD etcd service name, not WKS etcd

### DIFF
--- a/discovery-data/2.2.0/etcd-backup-restore.sh
+++ b/discovery-data/2.2.0/etcd-backup-restore.sh
@@ -51,7 +51,7 @@ rm -rf ${TMP_WORK_DIR}
 mkdir -p ${TMP_WORK_DIR}
 mkdir -p ${BACKUP_RESTORE_LOG_DIR}
 
-ETCD_SERVICE=`oc get svc ${OC_ARGS} -o jsonpath="{.items[*].metadata.name}" -l app=etcd | tr '[[:space:]]' '\n' | grep etcd-client`
+ETCD_SERVICE=`oc get svc ${OC_ARGS} -o jsonpath="{.items[*].metadata.name}" -l app=etcd | tr '[[:space:]]' '\n' | grep etcd-client | grep -e wd- -e discovery`
 ETCD_SECRET=`oc get secret ${OC_ARGS} -o jsonpath="{.items[0].metadata.name}" -l tenant=${TENANT_NAME},app=etcd-root`
 ETCD_USER=`oc get secret ${OC_ARGS} ${ETCD_SECRET} --template '{{.data.username}}' | base64 --decode`
 ETCD_PASSWORD=`oc get secret ${OC_ARGS} ${ETCD_SECRET} --template '{{.data.password}}' | base64 --decode`


### PR DESCRIPTION
If both WD 2.2.1 and WKS 1.2.0 are installed in CP4D 3.5 (may be true
for other configurations, but this is my only experience), then the etcd
backup script finds and returns two results when determining the name
of the etcd client service.

Returned values:
```
wd-discovery-etcd-client
wks-ibm-etcd-client
```

This breaks the later input and causes the `etcd-backup-restore.sh` script
to fail/error-out and not create any kind of backup.

This commit adds an additional `grep` to return only the WD etcd client
service name by filtering for `wd-` or `discovery`