### PR TITLE
BUG: for-loop index variable conflict bug

### DIFF
--- a/discovery-data/2.1.3/lib/function.bash
+++ b/discovery-data/2.1.3/lib/function.bash
@@ -190,9 +190,9 @@ kube_cp_from_local(){
     rm -rf ${SPLITE_DIR}
     mkdir -p ${SPLITE_DIR}
     split -a 5 -b ${SPLITE_SIZE} ${LOCAL_BACKUP} ${SPLITE_DIR}/${LOCAL_BASE_NAME}.split.
-    for file in ${SPLITE_DIR}/*; do
-      FILE_BASE_NAME=$(basename "${file}")
-      kubectl cp $@ "${file}" "${POD}:${POD_DIST_DIR}/${FILE_BASE_NAME}"
+    for splitfile in ${SPLITE_DIR}/*; do
+      FILE_BASE_NAME=$(basename "${splitfile}")
+      kubectl cp $@ "${splitfile}" "${POD}:${POD_DIST_DIR}/${FILE_BASE_NAME}"
     done
     rm -rf ${SPLITE_DIR}
     kubectl exec $@ ${POD} -- bash -c "cat ${POD_DIST_DIR}/${LOCAL_BASE_NAME}.split.* > ${POD_BACKUP} && rm -rf ${POD_DIST_DIR}/${LOCAL_BASE_NAME}.split.*"
@@ -248,9 +248,9 @@ kube_cp_to_local(){
     mkdir -p ${SPLITE_DIR}
     kubectl exec $@ ${POD} -- bash -c "split -d -a 5 -b ${SPLITE_SIZE} ${POD_BACKUP} ${POD_BACKUP}.split."
     FILE_LIST=`kubectl exec $@ ${POD} -- bash -c "ls ${POD_BACKUP}.split.*"`
-    for file in ${FILE_LIST} ; do
-      FILE_BASE_NAME=$(basename "${file}")
-      kubectl cp $@ "${POD}:${file}" "${SPLITE_DIR}/${FILE_BASE_NAME}"
+    for splitfile in ${FILE_LIST} ; do
+      FILE_BASE_NAME=$(basename "${splitfile}")
+      kubectl cp $@ "${POD}:${splitfile}" "${SPLIT_DIR}/${FILE_BASE_NAME}"
     done
     cat ${SPLITE_DIR}/* > ${LOCAL_BACKUP}
     rm -rf ${SPLITE_DIR}

--- a/discovery-data/2.2.0/lib/function.bash
+++ b/discovery-data/2.2.0/lib/function.bash
@@ -196,9 +196,9 @@ kube_cp_from_local(){
     rm -rf ${SPLITE_DIR}
     mkdir -p ${SPLITE_DIR}
     split -a 5 -b ${SPLITE_SIZE} ${LOCAL_BACKUP} ${SPLITE_DIR}/${LOCAL_BASE_NAME}.split.
-    for file in ${SPLITE_DIR}/*; do
-      FILE_BASE_NAME=$(basename "${file}")
-      oc cp $@ "${file}" "${POD}:${POD_DIST_DIR}/${FILE_BASE_NAME}"
+    for splitfile in ${SPLITE_DIR}/*; do
+      FILE_BASE_NAME=$(basename "${splitfile}")
+      oc cp $@ "${splitfile}" "${POD}:${POD_DIST_DIR}/${FILE_BASE_NAME}"
     done
     rm -rf ${SPLITE_DIR}
     run_cmd_in_pod ${POD} "cat ${POD_DIST_DIR}/${LOCAL_BASE_NAME}.split.* > ${POD_BACKUP} && rm -rf ${POD_DIST_DIR}/${LOCAL_BASE_NAME}.split.*" $@
@@ -253,9 +253,9 @@ kube_cp_to_local(){
     mkdir -p ${SPLITE_DIR}
     run_cmd_in_pod ${POD} "split -d -a 5 -b ${SPLITE_SIZE} ${POD_BACKUP} ${POD_BACKUP}.split." $@
     FILE_LIST=`oc exec $@ ${POD} -- sh -c "ls ${POD_BACKUP}.split.*"`
-    for file in ${FILE_LIST} ; do
-      FILE_BASE_NAME=$(basename "${file}")
-      oc cp $@ "${POD}:${file}" "${SPLITE_DIR}/${FILE_BASE_NAME}"
+    for splitfile in ${FILE_LIST} ; do
+      FILE_BASE_NAME=$(basename "${splitfile}")
+      oc cp $@ "${POD}:${splitfile}" "${SPLITE_DIR}/${FILE_BASE_NAME}"
     done
     cat ${SPLITE_DIR}/* > ${LOCAL_BACKUP}
     rm -rf ${SPLITE_DIR}


### PR DESCRIPTION
When any backup file is larger than the configured size-to-split, the
for-loop index variable `file` is reused and causes the process to
throw an error that the file is not found (because the reference to the
outer loop variable has been overwritten by the inner loop index var).

Simple fix is to rename the second index variable. Change made in both
2.1.3 and 2.2.0 versions