### PR TITLE
Scripts update for Watson Discovery 4.0.3 on CP4D

### DIFF
--- a/discovery-data/2.2.0/etcd-backup-restore.sh
+++ b/discovery-data/2.2.0/etcd-backup-restore.sh
@@ -51,7 +51,7 @@ rm -rf ${TMP_WORK_DIR}
 mkdir -p ${TMP_WORK_DIR}
 mkdir -p ${BACKUP_RESTORE_LOG_DIR}
 
-ETCD_SERVICE=`oc get svc ${OC_ARGS} -o jsonpath="{.items[*].metadata.name}" -l app=etcd | tr '[[:space:]]' '\n' | grep etcd-client | grep -e wd- -e discovery`
+ETCD_SERVICE=`oc get svc ${OC_ARGS} -o jsonpath="{.items[*].metadata.name}" -l app=etcd,tenant=${TENANT_NAME} | tr '[[:space:]]' '\n' | grep etcd-client`
 ETCD_SECRET=`oc get secret ${OC_ARGS} -o jsonpath="{.items[0].metadata.name}" -l tenant=${TENANT_NAME},app=etcd-root`
 ETCD_USER=`oc get secret ${OC_ARGS} ${ETCD_SECRET} --template '{{.data.username}}' | base64 --decode`
 ETCD_PASSWORD=`oc get secret ${OC_ARGS} ${ETCD_SECRET} --template '{{.data.password}}' | base64 --decode`

--- a/discovery-data/2.2.0/minio-backup-restore.sh
+++ b/discovery-data/2.2.0/minio-backup-restore.sh
@@ -141,7 +141,7 @@ if "${BACKUP_RESTORE_IN_POD}" ; then
   if [ "${COMMAND}" = "backup" ] ; then
     brlog "INFO" "Transferring backup data"
     kube_cp_to_local ${POD} "${BACKUP_FILE}" "${BACKUP_RESTORE_DIR_IN_POD}/${MINIO_BACKUP}" ${OC_ARGS}
-    if "${VERIFY_DATASTORE_ARCHIVE}" && brlog "INFO" "Verifying backup archive" && ! tar ${ELASTIC_TAR_OPTIONS[@]} -tf ${BACKUP_FILE} &> /dev/null ; then
+    if "${VERIFY_DATASTORE_ARCHIVE}" && brlog "INFO" "Verifying backup archive" && ! tar ${MINIO_TAR_OPTIONS[@]} -tf ${BACKUP_FILE} &> /dev/null ; then
       brlog "ERROR" "Backup file is broken, or does not exist."
       oc ${OC_ARGS} exec ${POD} -- bash -c "cd ${BACKUP_RESTORE_DIR_IN_POD}; ls | xargs rm -rf"
       exit 1

--- a/discovery-data/2.2.0/postgresql-backup-restore.sh
+++ b/discovery-data/2.2.0/postgresql-backup-restore.sh
@@ -215,8 +215,8 @@ if [ ${COMMAND} = 'restore' ] ; then
   export PGHOST=${HOSTNAME} && \
   cd tmp && \
   for DATABASE in $(ls '${PG_BACKUP_DIR}'/*.dump | cut -d "/" -f 2 | sed -e "s/^pg_//g" -e "s/.dump$//g"); do
-  psql -d ${DATABASE} -c "REVOKE CONNECT ON DATABASE ${DATABASE} FROM public;" && \
-  psql -d ${DATABASE} -c "SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();" && \
+  psql -d ${DATABASE} -c "REVOKE CONNECT ON DATABASE ${DATABASE} FROM public;" || true && \
+  psql -d ${DATABASE} -c "SELECT pid, pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid();" || true && \
   dropdb --if-exists ${DATABASE} && \
   createdb ${DATABASE} && \
   psql -d ${DATABASE} -c "GRANT CONNECT ON DATABASE ${DATABASE} TO public;" && \

--- a/discovery-data/2.2.0/src/postgresql-backup-restore-in-pod.sh
+++ b/discovery-data/2.2.0/src/postgresql-backup-restore-in-pod.sh
@@ -60,6 +60,10 @@ if [ ${COMMAND} = 'restore' ] ; then
   mkdir -p ${TMP_WORK_DIR}
   cd ${TMP_WORK_DIR}
 
+  if ! psql -d dadmin -c "SELECT id FROM tenants" | grep "default" > /dev/null ; then
+    psql -d dadmin -c "UPDATE tenants SET id = 'default'"
+  fi
+
   psql -d dadmin -c "\COPY tenants TO '${TMP_WORK_DIR}/tenants'"
   if ! cat "${TMP_WORK_DIR}/tenants" | grep "default" > /dev/null ; then
     brlog "ERROR" "Can not get tenant information"

--- a/discovery-data/2.2.0/version.txt
+++ b/discovery-data/2.2.0/version.txt
@@ -1,2 +1,2 @@
 The Backup and Restore Scripts for the Watson Discovery on CP4D.
-Scripts Version: 4.0.2
+Scripts Version: 4.0.3


### PR DESCRIPTION
This PR includes script updates for backup/restore of Watson Discovery 4.0.3 on CP4D.
This also includes a fix for Watson Discovery 2.2.0 or later.

- Timeout error while waiting job pod.
- Failed to get tenant ID if it is UUID.
- Failed to get etcd service if a namespace have multiple etcd cluster
- Scripts pick old job pod when it initialize core database.
- MinIO backup fails due to undefined variable when specify --use-job.