### PR TITLE
Update etcd service to use localhost instead of serve

### DIFF
--- a/discovery-data/latest/lib/function.bash
+++ b/discovery-data/latest/lib/function.bash
@@ -1036,11 +1036,7 @@ check_etcd_available(){
 }
 
 setup_etcd_env(){
-  ETCD_SERVICE=$(oc get svc ${OC_ARGS} -o jsonpath="{.items[*].metadata.name}" -l "app=etcd,tenant=${TENANT_NAME}" | tr '[[:space:]]' '\n' | grep etcd-client || echo "")
-  if [ -z "${ETCD_SERVICE}" ] ; then
-    # Etcd label changed on 4.0.4
-    ETCD_SERVICE=$(oc get svc ${OC_ARGS} -o jsonpath="{.items[*].metadata.name}" -l "app=etcd,etcd_cluster=${TENANT_NAME}-discovery-etcd" | tr '[[:space:]]' '\n' | grep etcd-client)
-  fi
+  ETCD_SERVICE="localhost"
   ETCD_ENDPOINT="https://${ETCD_SERVICE}:2379"
   ETCD_SECRET=$(oc get secret ${OC_ARGS} -o jsonpath="{.items[0].metadata.name}" -l "tenant=${TENANT_NAME},app in (etcd,etcd-root)")
   ETCD_USER=$(oc get secret ${OC_ARGS} ${ETCD_SECRET} --template '{{.data.username}}' | base64 --decode)


### PR DESCRIPTION
Small update for backup/restore of Watson Discovery 4.6.5 on CP4D.
This PR fixes restore that fails during etcd due to inconsistent service for wd etcd client on some clusters. 