### PR TITLE
Fix scripts for Watson Discovery 4.7.0 and 4.5.x on CP4D

### DIFF
--- a/discovery-data/latest/all-backup-restore.sh
+++ b/discovery-data/latest/all-backup-restore.sh
@@ -477,6 +477,9 @@ if [ "${COMMAND}" = 'restore' ] ; then
       ${SCRIPT_DIR}/mt-mt-migration.sh -i ${TENANT_NAME}
     fi
   fi
+  if [ $(compare_version "${WD_VERSION}" "4.7.0") -ge 0 ] ; then
+    restart_job "enrichment-model-copy orchestrator-setup"
+  fi
 fi
 
 if ! "${SKIP_QUIESCE}" ; then

--- a/discovery-data/latest/lib/function.bash
+++ b/discovery-data/latest/lib/function.bash
@@ -1099,7 +1099,7 @@ launch_s3_pod(){
 }
 
 setup_s3_env(){
-  S3_CONFIGMAP=${S3_CONFIGMAP:-$(oc get ${OC_ARGS} cm -l "discovery.ibm.com/component in (s3,minio),tenant=${TENANT_NAME}" -o jsonpath="{.items[*].metadata.name}")}
+  S3_CONFIGMAP=${S3_CONFIGMAP:-$(oc get ${OC_ARGS} cm -l "app.kubernetes.io/component in (s3,minio),tenant=${TENANT_NAME}" -o jsonpath="{.items[*].metadata.name}")}
   S3_SVC=${S3_SVC:-$(oc extract ${OC_ARGS} configmap/${S3_CONFIGMAP} --keys=host --to=- 2> /dev/null)}
   if [[ "${S3_SVC}" == *"."* ]] ; then
     array=(${S3_SVC//./ })

--- a/discovery-data/latest/minio-backup-restore.sh
+++ b/discovery-data/latest/minio-backup-restore.sh
@@ -206,7 +206,6 @@ if [ "${COMMAND}" = "restore" ] ; then
   stop_minio_port_forward
   brlog "INFO" "Done"
   brlog "INFO" "Restart setup jobs"
-  restart_job "enrichment-model-copy orchestrator-setup"
   brlog "INFO" "Applying updates"
   . ./lib/restore-updates.bash
   minio_updates


### PR DESCRIPTION
Fix backup restore scripts for Watson Discovery 4.7.0 and 4.5.x
- Fix issue after restore to 4.7.0.
- Fix `s3 not available` error on 4.5.x or prior.