### PR TITLE
Update script for Watson Discovery 4.6.x and 4.7.3 on CP4D

### DIFF
--- a/discovery-data/latest/elastic-backup-restore.sh
+++ b/discovery-data/latest/elastic-backup-restore.sh
@@ -158,13 +158,12 @@ if "${BACKUP_RESTORE_IN_POD}" && [ $(compare_version ${WD_VERSION} "4.7.0") -lt 
   add_secret_env_to_job_yaml "S3_SECRET_KEY" "${S3_SECRET}" "secretkey" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "ELASTIC_ARCHIVE_OPTION" "${ELASTIC_ARCHIVE_OPTION}" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "ELASTIC_STATUS_CHECK_INTERVAL" "${ELASTIC_STATUS_CHECK_INTERVAL}" "${ELASTIC_JOB_FILE}"
-  add_env_to_job_yaml "ELASTIC_ARCHIVE_OPTION" "${ELASTIC_ARCHIVE_OPTION}" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "ELASTIC_WAIT_GREEN_STATE" "${ELASTIC_WAIT_GREEN_STATE}" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "DISABLE_MC_MULTIPART" "${DISABLE_MC_MULTIPART}" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "TZ" "${TZ_OFFSET}" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "KEEP_SNAPSHOT" "${KEEP_SNAPSHOT}" "${ELASTIC_JOB_FILE}"
   add_env_to_job_yaml "ELASTIC_MAX_WAIT_RECOVERY_SECONDS" "${ELASTIC_MAX_WAIT_RECOVERY_SECONDS}" "${ELASTIC_JOB_FILE}"
-  add_volume_to_job_yaml "backup-restore-workspace" "${JOB_VOLUME_NAME}" "${TMP_PVC_NAME:-emptyDir}" "${ELASTIC_JOB_FILE}"
+  add_volume_to_job_yaml "backup-restore-workspace" "${TMP_PVC_NAME:-emptyDir}" "${ELASTIC_JOB_FILE}"
 
   oc ${OC_ARGS} delete -f "${ELASTIC_JOB_FILE}" &> /dev/null || true
   oc ${OC_ARGS} apply -f "${ELASTIC_JOB_FILE}"

--- a/discovery-data/latest/lib/function.bash
+++ b/discovery-data/latest/lib/function.bash
@@ -1080,6 +1080,7 @@ launch_s3_pod(){
   if [ -n "${MINIO_ARCHIVE_OPTION:+UNDEF}" ] ; then add_env_to_job_yaml "MINIO_ARCHIVE_OPTION" "${MINIO_ARCHIVE_OPTION}" "${S3_JOB_FILE}"; fi
   if [ -n "${DISABLE_MC_MULTIPART:+UNDEF}" ] ; then add_env_to_job_yaml "DISABLE_MC_MULTIPART" "${DISABLE_MC_MULTIPART}" "${S3_JOB_FILE}"; fi
   add_env_to_job_yaml "TZ" "${TZ_OFFSET}" "${S3_JOB_FILE}"
+  add_env_to_job_yaml "WD_VERSION" "${wd_version}" "${S3_JOB_FILE}"
   add_volume_to_job_yaml "backup-restore-workspace" "${TMP_PVC_NAME:-emptyDir}" "${S3_JOB_FILE}"
   if [ $(compare_version ${wd_version} "4.7.0") -ge 0 ] ; then
     BUCKET_SUFFIX="$(get_bucket_suffix)"

--- a/discovery-data/latest/mt-mt-migration.sh
+++ b/discovery-data/latest/mt-mt-migration.sh
@@ -119,8 +119,10 @@ do
   CMD="psql -d dadmin -t -A -c \"SELECT table_name FROM information_schema.columns WHERE table_schema = 'public' AND column_name = 'tenant_id' ORDER BY table_name\""
   standard_mt_tables=($(oc exec ${OC_ARGS} "${PG_POD}" -- bash -c "${CMD}"))
   echo "Updating tables with tenant_id: ${standard_mt_tables[*]}"
-  foreign_key_tables=(wd_collections wd_collections_status wd_collections_project wd_datasets_collection wd_collection_document_status wd_collections_enrichment_job_status wd_datasets wd_datasets_status wd_datasets_project wd_enrichments wd_enrichments_lang wd_enrichments_project wd_collection_stats)
-
+  foreign_key_tables=(wd_collections wd_collections_status wd_collections_project wd_datasets_collection wd_collection_document_status wd_collections_enrichment_job_status wd_datasets wd_datasets_status wd_datasets_project wd_enrichments wd_enrichments_lang wd_enrichments_project)
+  if [ $(compare_version "${WD_VERSION}" "4.7.0") -ge 0 ] ; then
+    foreign_key_tables+=( wd_collection_stats )
+  fi
   SQL="BEGIN;"
 
   for table in "${foreign_key_tables[@]}"; do

--- a/discovery-data/latest/src/elastic-backup-restore-in-pod.sh
+++ b/discovery-data/latest/src/elastic-backup-restore-in-pod.sh
@@ -25,9 +25,9 @@ ELASTIC_LOG="${TMP_WORK_DIR}/elastic.log"
 
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir ${MINIO_CONFIG_DIR} --insecure)
-MC_MIRROR_OPTS=( "" )
+MC_MIRROR_OPTS=()
 if "${DISABLE_MC_MULTIPART:-true}" ; then
-  MC_MIRROR_OPTS=( "${MC_MIRROR_OPTS[@]}" --disable-multipart )
+  MC_MIRROR_OPTS+=( "--disable-multipart" )
 fi
 MC=mc
 

--- a/discovery-data/latest/src/mcg_exclude_paths
+++ b/discovery-data/latest/src/mcg_exclude_paths
@@ -1,0 +1,3 @@
+# bucket paths
+common mt/__built-in-tenant__/fileResource*
+common watson_nlp_models*

--- a/discovery-data/latest/version.txt
+++ b/discovery-data/latest/version.txt
@@ -1,2 +1,2 @@
 The Backup and Restore Scripts for the Watson Discovery on CP4D.
-Scripts Version: 4.7.1
+Scripts Version: 4.7.3


### PR DESCRIPTION
This PR includes update for backup and restore scripts for Watson Discovery 4.7.3 on CP4D and some bug fix for 4.6.x.
- Fix unassigned variable error while elastic backup or restore
- Fix unknown relation error while mt migration