### PR TITLE
updated granite model reference to ibm/granite-13b-instruct-v2

### DIFF
--- a/discovery-data/webhook-enrichment-sample/granite/main.py
+++ b/discovery-data/webhook-enrichment-sample/granite/main.py
@@ -40,7 +40,7 @@ def extract_entities(text):
         IAM_TOKEN = get_iam_token()
     # Prompt
     payload = {
-        'model_id': 'ibm/granite-13b-instruct-v1',
+        'model_id': 'ibm/granite-13b-instruct-v2',
         'input': f'''Act as a webmaster who must extract structured information from emails. Read the below email and extract and categorize each entity. If no entity is found, output "None".
 
 Input:


### PR DESCRIPTION
ibm/granite-13b-instruct-v1 is no longer supported. It threw an error in watson Discovery when I tried the tutorial. 