### PR TITLE
fix: exporting HOME env to avoid mc config error.

### DIFF
--- a/discovery-data/latest/src/elastic-backup-restore-in-pod.sh
+++ b/discovery-data/latest/src/elastic-backup-restore-in-pod.sh
@@ -23,6 +23,8 @@ TMP_WORK_DIR="/tmp/backup-restore-workspace"
 CURRENT_COMPONENT="elastic"
 ELASTIC_LOG="${TMP_WORK_DIR}/elastic.log"
 
+# Need to export HOME on OCP 4.18　which is used to configure the default mc config directory.
+export HOME="${TMP_WORK_DIR}"
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir ${MINIO_CONFIG_DIR} --insecure)
 MC_MIRROR_OPTS=()

--- a/discovery-data/latest/src/minio-backup-restore-in-pod.sh
+++ b/discovery-data/latest/src/minio-backup-restore-in-pod.sh
@@ -35,6 +35,8 @@ VERIFY_DATASTORE_ARCHIVE=${VERIFY_DATASTORE_ARCHIVE-true}
 mkdir -p ${TMP_WORK_DIR}/${MINIO_BACKUP_DIR}
 mkdir -p ${TMP_WORK_DIR}/.mc
 MC=mc
+# Need to export HOME on OCP 4.18　which is used to configure the default mc config directory.
+export HOME="${TMP_WORK_DIR}"
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir "${MINIO_CONFIG_DIR}" --insecure)
 MC_MIRROR_OPTS=()

--- a/discovery-data/latest/src/minio-mt-migration.sh
+++ b/discovery-data/latest/src/minio-mt-migration.sh
@@ -61,6 +61,8 @@ fi
 
 mkdir -p ${TMP_WORK_DIR}/.mc
 MC=mc
+# Need to export HOME on OCP 4.18　which is used to configure the default mc config directory.
+export HOME="${TMP_WORK_DIR}"
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir ${MINIO_CONFIG_DIR} --insecure)
 


### PR DESCRIPTION
`mc` command caused `mc: <ERROR> Unable to get mcConfigDir. exit status 2.` on OCP 4.18 cluster. Although the root cause is unknown, it seems the command cannot access to the specified config dir. If that is the case, the default config directory is used, which is constructed with `HOME` variable, but this variable was empty inside of the pods. 

This PR export `HOME` to avoid mc config error. 