### PR TITLE
chore: updating watson discovery backup restore script for 5.2.1.

### DIFF
--- a/discovery-data/latest/elastic-backup-restore.sh
+++ b/discovery-data/latest/elastic-backup-restore.sh
@@ -436,7 +436,7 @@ if [ ${COMMAND} = 'backup' ] ; then
   if [ $(compare_version ${WD_VERSION} "4.7.0") -lt 0 ] ; then
     # Clean up MinIO
     start_minio_port_forward
-    "${MC}" "${MC_OPTS[@]}" config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
+    mc_set_alias
     if [ -n "$("${MC}" "${MC_OPTS[@]}" ls wdminio/${ELASTIC_BACKUP_BUCKET}/)" ] ; then
       "${MC}" "${MC_OPTS[@]}" rm --recursive --force --dangerous wdminio/${ELASTIC_BACKUP_BUCKET}/ > /dev/null
     fi
@@ -526,7 +526,7 @@ if [ "${COMMAND}" = 'restore' ] ; then
     tar "${ELASTIC_TAR_OPTIONS[@]}" -xf ${BACKUP_FILE} -C ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
     brlog "INFO" "Transferring data to MinIO..."
     start_minio_port_forward
-    "${MC}" "${MC_OPTS[@]}" config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
+    mc_set_alias
     if [ -n "$("${MC}" "${MC_OPTS[@]}" ls wdminio/${ELASTIC_BACKUP_BUCKET}/)" ] ; then
       "${MC}" "${MC_OPTS[@]}" rm --recursive --force --dangerous wdminio/${ELASTIC_BACKUP_BUCKET}/ > /dev/null
     fi

--- a/discovery-data/latest/mt-mt-migration.sh
+++ b/discovery-data/latest/mt-mt-migration.sh
@@ -225,12 +225,18 @@ do
   ##############
 
   brlog "INFO" "    Migrating MinIO contents"
-
   bucket_suffix="$(get_bucket_suffix)"
+  _oc_cp "${SCRIPT_DIR}/src" ${MC_POD}:${BACKUP_RESTORE_DIR_IN_POD}/ ${OC_ARGS}
+  _oc_cp "${SCRIPT_DIR}/lib" ${MC_POD}:${BACKUP_RESTORE_DIR_IN_POD}/ ${OC_ARGS}
+  _oc_cp "${SCRIPT_DIR}/src/minio-mt-migration.sh" "${MC_POD}:${BACKUP_RESTORE_DIR_IN_POD}/minio-mt-migration.sh" ${OC_ARGS}
   if [ -n "${bucket_suffix}" ] ; then
-    run_script_in_pod ${MC_POD} "${SCRIPT_DIR}/src/minio-mt-migration.sh" "-s ${src} -t ${dst} --suffix ${bucket_suffix}"
+    run_cmd_in_pod ${MC_POD} \
+    "${BACKUP_RESTORE_DIR_IN_POD}/minio-mt-migration.sh -s ${src} -t ${dst} --suffix ${bucket_suffix}" \
+    ${OC_ARGS}
   else
-    run_script_in_pod ${MC_POD} "${SCRIPT_DIR}/src/minio-mt-migration.sh" "-s ${src} -t ${dst}"
+    run_cmd_in_pod ${MC_POD} \
+    "${BACKUP_RESTORE_DIR_IN_POD}/minio-mt-migration.sh -s ${src} -t ${dst}" \
+    ${OC_ARGS}
   fi
 
   ##############

--- a/discovery-data/latest/src/elastic-backup-restore-in-pod.sh
+++ b/discovery-data/latest/src/elastic-backup-restore-in-pod.sh
@@ -67,7 +67,7 @@ function clean_up(){
 }
 
 if [ "${COMMAND}" = "backup" ] ; then
-  "${MC}" ${MC_OPTS[@]} config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
+  mc_set_alias
   if [ -n "$("${MC}" ${MC_OPTS[@]} ls wdminio/${ELASTIC_BACKUP_BUCKET}/)" ] ; then
     "${MC}" ${MC_OPTS[@]} rm --recursive --force --dangerous wdminio/${ELASTIC_BACKUP_BUCKET}/ > /dev/null
   fi
@@ -130,7 +130,7 @@ elif [ "${COMMAND}" = "restore" ] ; then
   tar "${ELASTIC_TAR_OPTIONS[@]}" -xf ${ELASTIC_BACKUP} -C ${TMP_WORK_DIR}/${ELASTIC_BACKUP_DIR}/${ELASTIC_BACKUP_BUCKET}/${ELASTIC_SNAPSHOT_PATH}
   rm -f ${ELASTIC_BACKUP}
   brlog "INFO" "Transferring data to MinIO..."
-  "${MC}" "${MC_OPTS[@]}" config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
+  mc_set_alias
   if [ -n "$("${MC}" "${MC_OPTS[@]}" ls wdminio/${ELASTIC_BACKUP_BUCKET}/)" ] ; then
     "${MC}" "${MC_OPTS[@]}" rm --recursive --force --dangerous wdminio/${ELASTIC_BACKUP_BUCKET}/ > /dev/null
   fi

--- a/discovery-data/latest/src/minio-backup-restore-in-pod.sh
+++ b/discovery-data/latest/src/minio-backup-restore-in-pod.sh
@@ -51,7 +51,7 @@ S3_BUCKETS=${S3_BUCKETS:-}
 if [ "${COMMAND}" = "backup" ] ; then
   brlog "INFO" "Start backup minio"
   brlog "INFO" "Backup data..."
-  "${MC}" "${MC_OPTS[@]}" --quiet config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
+  mc_set_alias
   EXCLUDE_OBJECTS=$(cat "${SCRIPT_DIR}/src/minio_exclude_paths")
   if [ $(compare_version "$(get_version)" "4.7.0") -ge 0 ] ; then
     EXCLUDE_OBJECTS+=$'\n'
@@ -106,7 +106,7 @@ if [ "${COMMAND}" = "restore" ] ; then
   tar "${MINIO_TAR_OPTIONS[@]}" -xf ${MINIO_BACKUP} -C ${TMP_WORK_DIR}/${MINIO_BACKUP_DIR}
   rm -f ${MINIO_BACKUP}
   brlog "INFO" "Restoring data..."
-  "${MC}" "${MC_OPTS[@]}" --quiet config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
+  mc_set_alias
   for bucket_path in "${TMP_WORK_DIR}/${MINIO_BACKUP_DIR}"/*
   do
     bucket="$(basename "${bucket_path}")"

--- a/discovery-data/latest/src/minio-mt-migration.sh
+++ b/discovery-data/latest/src/minio-mt-migration.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 TMP_WORK_DIR="/tmp/backup-restore-workspace"
-
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/lib/function.bash"
 
 show_help(){
 cat << EOS
@@ -66,8 +67,7 @@ export HOME="${TMP_WORK_DIR}"
 export MINIO_CONFIG_DIR="${TMP_WORK_DIR}/.mc"
 MC_OPTS=(--config-dir ${MINIO_CONFIG_DIR} --insecure)
 
-"${MC}" ${MC_OPTS[@]} --quiet config host add wdminio ${S3_ENDPOINT_URL} ${S3_ACCESS_KEY} ${S3_SECRET_KEY} > /dev/null
-
+mc_set_alias
 for LOCATION in "cnm${bucket_suffix}/mt" "common${bucket_suffix}/mt" "exported-documents${bucket_suffix}"; do
   FOLDERS=$( ("${MC}" ${MC_OPTS[@]} --quiet --json ls "wdminio/${LOCATION}/${source}" || echo '{}') | jq -r '.key|values')
   for FOLDER in ${FOLDERS[@]}; do

--- a/discovery-data/latest/src/s3-backup-restore-in-pod.sh
+++ b/discovery-data/latest/src/s3-backup-restore-in-pod.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "${SCRIPT_DIR}/lib/function.bash"
+
+s3_buckets=${S3_BUCKETS:-}
+s3_access_key="${S3_ACCESS_KEY:-dummy_key}"
+s3_secret_key="${S3_SECRET_KEY:-dummy_key}"
+s3_endpoint="${S3_ENDPOINT_URL:-https://localhost}"
+s3_backup_dir=${S3_BACKUP_DIR:-s3_backup}
+s3_cert_path="${S3_CERT_PATH:-/tmp/ca.cert}"
+s3_common_bucket="${S3_COMMON_BUCKET:-common}"
+aws_config_dir="${S3_CONFIG_DIR:-/tmp/.aws}"
+
+show_help(){
+cat << EOS
+Usage: $0 (backup|restore) [options]
+
+Options:
+  -h, --help              Print help info
+  -f, --file              Backup file name
+  -d, --backup-dir       Directory where the backup file will be saved (when backup) or retrieved from (when restore)
+  -l, --log-level         Log level. "ERROR", "WARN", "INFO" or "DEBUG"
+EOS
+}
+
+check_bucket_exists() {
+  local bucket=$1
+  result="$(aws s3 "${aws_args[@]}" ls "s3://${bucket}" 2>&1)"
+  rc=$?
+  if [ $rc -eq 0 ] ; then
+    return 0
+  elif echo "${result}" | grep "NoSuchBucket" > /dev/null ; then
+    # bucket does not exists
+    return 1
+  else
+    echo "${result}" >&2
+    return 2
+  fi
+}
+
+sync_bucket() {
+  local bucket=$1
+  local src=$2
+  local dst=$3
+  local extra=${4:-}
+
+  brlog "DEBUG" "sync_bucket bucket:${bucket} src:${src} dst:${dst} extra:${extra}"
+
+  set +eo pipefail
+  brlog "INFO" "Check if ${bucket} exists"
+  check_bucket_exists "${bucket}"
+  rc=$?
+  set -eo pipefail
+  if [ $rc -eq 0 ] ; then
+    brlog "INFO" "Bucket '${bucket}' exists."
+  elif [ $rc -eq 1 ] ; then
+    brlog "WARN" "bucket does not exists: '${bucket}'"
+    brlog "INFO" "Create bucket"
+    aws s3 mb "${aws_args[@]}" "s3://${bucket}"
+  else
+    brlog "ERROR" "Unexpected error"
+    exit 1
+  fi
+
+  brlog "INFO" "Start sync"
+  set -x
+  aws s3 sync "${aws_args[@]}" --no-progress --delete "${src}" "${dst}" ${extra}
+  set +x
+}
+
+while (( $# > 0 )); do
+  case "$1" in
+    -h | --help )
+      show_help
+      exit 0
+      ;;
+    -l | --log-level)
+      if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
+        brlog "ERROR" "option requires an argument: $1"
+        exit 1
+      fi
+      export BACKUP_RESTORE_LOG_LEVEL="$2"
+      shift 1
+      ;;
+    -f | --file)
+      if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
+        brlog "ERROR" "option requires an argument: $1"
+        exit 1
+      fi
+      s3_backup_file="$2"
+      shift 1
+      ;;
+    -d | --backup-dir)
+      if [[ -z "$2" ]] || [[ "$2" =~ ^-+ ]]; then
+        brlog "ERROR" "option requires an argument: $1"
+        exit 1
+      fi
+      s3_backup_dir="$2"
+      shift 1
+      ;;
+    *)
+      if [[ ! -z "$1" ]] && [[ ! "$1" =~ ^-+ ]]; then
+        if [ "$1" = "backup" -o "$1" = "restore" ] ; then
+          COMMAND=$1
+        else
+          brlog "ERROR" "illegal argument: $1"
+          exit 1
+        fi
+      fi
+      ;;
+  esac
+  shift
+done
+
+if [ -n "${MINIO_ARCHIVE_OPTION}" ] ; then
+  read -a MINIO_TAR_OPTIONS <<< ${MINIO_ARCHIVE_OPTION}
+else
+  MINIO_TAR_OPTIONS=("")
+fi
+VERIFY_DATASTORE_ARCHIVE=${VERIFY_DATASTORE_ARCHIVE-true}
+
+# NOTE: reload the function once necessary variables are exported.
+source "${SCRIPT_DIR}/lib/function.bash"
+
+brlog "INFO" "S3 ${COMMAND}"
+brlog "DEBUG" "s3_backup_file: ${s3_backup_file}"
+brlog "DEBUG" "s3_backup_dir: ${s3_backup_dir}"
+brlog "DEBUG" "s3_buckets: ${s3_buckets}"
+
+# Configure credentials.
+brlog "INFO" "Start ${COMMAND}: ${s3_buckets}"
+rm -rf ${aws_config_dir}
+mkdir -p ${aws_config_dir}
+export AWS_CONFIG_FILE="${aws_config_dir}/config"
+export AWS_SHARED_CREDENTIALS_FILE="${aws_config_dir}/credentials"
+rm -f "${AWS_SHARED_CREDENTIALS_FILE}"
+cat <<EOF > "${AWS_SHARED_CREDENTIALS_FILE}"
+[default]
+aws_access_key_id=${s3_access_key}
+aws_secret_access_key=${s3_secret_key}
+EOF
+aws_args=( --endpoint-url "${s3_endpoint}" --ca-bundle "${s3_cert_path}" )
+brlog "INFO" "Existing s3 buckets:"
+aws s3 "${aws_args[@]}" ls "s3://${s3_common_bucket}"
+
+if [ "${COMMAND}" = "restore" ] ; then
+  brlog "INFO" "Unpacking backup source data ..."
+  tar "${MINIO_TAR_OPTIONS[@]}" -xf "${s3_backup_dir}/${s3_backup_file}" -C "${s3_backup_dir}"
+  # Remove extracted backup source file.
+  rm -f "${s3_backup_dir}/${s3_backup_file}"
+
+  # Restore each bucket.
+  for bucket_path in "${s3_backup_dir}"/*
+  do
+    bucket="$(basename "${bucket_path}")"
+    # Add bucket suffix if needed.
+    if [ -n "${BUCKET_SUFFIX}" ] && [[ "${bucket}" != *"${BUCKET_SUFFIX}" ]] ; then
+      mv "${s3_backup_dir}/${bucket}" "${s3_backup_dir}/${bucket}${BUCKET_SUFFIX}"
+      bucket="${bucket}${BUCKET_SUFFIX}"
+    fi
+    brlog "INFO" "Process ${bucket}"
+    sync_bucket "${bucket}" "${s3_backup_dir}/${bucket}" "s3://${bucket}"
+  done
+  brlog "INFO" "Restore successfully completed."
+fi 
+
+if [ "${COMMAND}" = "backup" ] ; then
+  mkdir -p "${s3_backup_dir}"
+  buckets=(${s3_buckets//,/ })
+  EXCLUDE_OBJECTS=$(cat "${SCRIPT_DIR}/src/minio_exclude_paths")
+  EXCLUDE_OBJECTS+=$'\n'
+  EXCLUDE_OBJECTS+="$(cat "${SCRIPT_DIR}/src/mcg_exclude_paths")"
+  brlog "DEBUG" "EXCLUDE_OBJECTS: ${EXCLUDE_OBJECTS[*]}"
+
+  # Backup each bucket.
+  for bucket in "${buckets[@]}"
+  do
+    brlog "INFO" "Process ${bucket}"
+    # Get exclude arguments.  
+    EXTRA_AWS_SYNC_COMMAND=()
+    ORG_IFS=${IFS}
+    IFS=$'\n'
+    for line in ${EXCLUDE_OBJECTS}
+    do
+      base_bucket_name=${bucket%"${BUCKET_SUFFIX}"}
+      brlog "DEBUG" "base_bucket_name: ${base_bucket_name}"
+      if [[ ${line} == ${base_bucket_name}* ]] ; then
+        exclude_bucket_name="${line#"$base_bucket_name" }"
+        if [ "${exclude_bucket_name}" = "*" ] ; then
+          brlog "DEBUG" "SKIP ${bucket}"
+          continue 2
+        fi
+        EXTRA_AWS_SYNC_COMMAND+=( "--exclude" "${exclude_bucket_name}" )
+      fi
+    done
+    IFS=${ORG_IFS}
+    brlog "DEBUG" "EXTRA_AWS_SYNC_COMMAND: ${EXTRA_AWS_SYNC_COMMAND[*]}"
+    sync_bucket "${bucket}" "s3://${bucket}" "${s3_backup_dir}/${bucket}" "${EXTRA_AWS_SYNC_COMMAND[*]}"
+  done
+  archive_backup "${s3_backup_file}" "${s3_backup_dir}" "${MINIO_TAR_OPTIONS[@]}"
+  brlog "INFO" "Backup created"
+fi
+
+brlog "INFO" "S3 ${COMMAND} DONE."

--- a/discovery-data/latest/version.txt
+++ b/discovery-data/latest/version.txt
@@ -1,2 +1,2 @@
 The Backup and Restore Scripts for the Watson Discovery on CP4D.
-Scripts Version: 5.2.0
+Scripts Version: 5.2.1


### PR DESCRIPTION
Updated watson discovery's backup restore script for 5.2.1:

- update script version info
- Use aws s3 cli instead of mc command
- improve some log messages

